### PR TITLE
[chore] Add code owners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# The API governance team is the default owner for everything in the repo.
+# (Note: CODEOWNERS follow a "last match wins" system.)
+*                   @googleapis/api-governance
+
+# These AIP editors own the generally-applicable AIP guidance.
+# PA-specific directories are owned by their respective teams.
+aip/*.md            @googleapis/aip-editors
+
+# Team-specific components are owned by those teams.
+aip/apps/27*.md     @googleapis/aip-apps
+aip/cloud/25*.md    @googleapis/aip-cloud
+aip/geo/46*.md      @googleapis/aip-geo


### PR DESCRIPTION
This adds code owners for the specific segments of the AIP repo, which allows us to set up branch protection.