### PR TITLE
[AIP-155] Request identification

### DIFF
--- a/aip/0155.md
+++ b/aip/0155.md
@@ -51,11 +51,12 @@ message CreateBookRequest {
   it applies (and it **must not** be a field on resources themselves).
 - Request IDs **should** be optional.
 - Request IDs **should** be able to be UUIDs, and **may** allow UUIDs to be the
-  only valid format.
+  only valid format. The format restrictions for request IDs **must** be
+  documented.
 
 ### Stale success responses
 
-In some unusual situations, it may not be possible to return an idential
+In some unusual situations, it may not be possible to return an identical
 success response. For example, a duplicate request to create a resource may
 arrive after the resource has not only been created, but subsequently updated;
 because the service has no other need to retain the historical data, it is no

--- a/aip/0155.md
+++ b/aip/0155.md
@@ -1,0 +1,66 @@
+---
+aip:
+  id: 155
+  state: reviewing
+  created: 2019-05-06
+permalink: /155
+redirect_from:
+  - /0155
+---
+
+# Request identification
+
+It is sometimes useful for an API to have a unique, customer-provided
+identifier for particular requests. This can be useful for several purposes,
+such as de-duplicating requests from parallel processes, ensuring the safety of
+retries, or auditing.
+
+The most important purpose for request IDs is to provide idempotency
+guarantees: allowing the same request to be issued more than once without
+subsequent calls having any effect. In the event of a network failure, the
+client can retry the request, and the server can detect duplication and ensure
+that the request is only processed once.
+
+## Guidance
+
+APIs **may** add a `string request_id` parameter to request messages (including
+those of standard methods) in order to uniquely identify particular requests.
+
+```proto
+message CreateBookRequest {
+  // The parent resource where this book will be created.
+  // Format: shelves/{shelf}
+  string parent = 1;
+
+  // The book to create.
+  Book book = 2;
+
+  // A unique identifier for this request. Restricted to 36 ASCII characters.
+  // A random UUID is recommended.
+  // This request is only idempotent if a `request_id` is provided.
+  string request_id = 3;
+}
+```
+
+- Providing a request ID **must** guarantee idempotency.
+  - If a duplicate request is detected, the server **should** return the
+    response for the previously successful request, because the client most
+    likely did not receive the previous response.
+  - APIs **may** choose any reasonable timeframe for honoring request IDs.
+- The `request_id` field **must** be provided on the request message to which
+  it applies (and it **must not** be a field on resources themselves).
+- Request IDs **should** be optional.
+- Request IDs **should** be able to be UUIDs, and **may** allow UUIDs to be the
+  only valid format.
+
+### Stale success responses
+
+In some unusual situations, it may not be possible to return an idential
+success response. For example, a duplicate request to create a resource may
+arrive after the resource has not only been created, but subsequently updated;
+because the service has no other need to retain the historical data, it is no
+longer feasible to return an identical success response.
+
+In this situation, the method **may** return the current state of the resource
+instead. In other words, it is permissible to substitute the historical success
+response with a similar response that reflects more current data.


### PR DESCRIPTION
Add an AIP for the `request_id` parameter (primarily used for de-duplication).