### PR TITLE
Updated formatting for AIP listing tables

### DIFF
--- a/_sass/aip/tables.scss
+++ b/_sass/aip/tables.scss
@@ -7,12 +7,20 @@
       @extend .h-c-table--datatable;
 
       &.aip-listing {
-        th, td {
-          &:first-child {
-            width: 125px;
-          }
+        margin-top: 10px;
+        tr:first-child {
+          border-top: 2px solid $h-gm-grey-500;
         }
-        th, td {
+        th {
+          display: none;
+        }
+        td {
+          // The Number column.
+          &:first-child {
+            width: 70px;
+          }
+
+          // The State column.
           &:nth-child(3) {
             width: 125px;
           }


### PR DESCRIPTION
I removed the headings since they were redundant and kind of ugly. I also made the number column 70px (enough for 4 digits at the current size). Lastly, I added a buffer between the heading and the table, and put a thick border along the top of the table to separate it from the headings.


![image](https://user-images.githubusercontent.com/112928/57398115-3df7d600-719c-11e9-84c5-497ccf7cee22.png)
