### PR TITLE
Updated callout colors

### DIFF
--- a/_sass/callouts.scss
+++ b/_sass/callouts.scss
@@ -5,34 +5,35 @@
   margin-left: 20px;
   margin-right: 20px;
   padding: 10px 20px;
+  color: $h-gm-grey-800;
 }
 
 .important {
   @extend .callout;
   background-color: $h-google-yellow-50;
-  border: 1px solid $h-google-yellow-100;
-  color: $h-google-yellow-800;
+  border: 1px solid $h-google-yellow-200;
 }
 
 .note {
   @extend .callout;
   background-color: $h-google-blue-50;
-  border: 1px solid $h-google-blue-100;
-  color: $h-info-color;
+  border: 1px solid $h-google-blue-200;
 }
 
 .tldr {
   @extend .callout;
   background-color: $h-google-green-50;
-  border: 1px solid $h-google-green-100;
-  color: $h-success-color;
+  border: 1px solid $h-google-green-200;
 }
 
 .warning {
   @extend .callout;
   background-color: $h-google-red-50;
-  border: 1px solid $h-google-red-100;
-  color: $h-warning-color;
+  border: 1px solid $h-google-red-200;
+}
+
+code {
+  font-size: 90% !important;
 }
 
 .docs-component-main pre {


### PR DESCRIPTION
The background colors looked fine, but the text color could be a bit jarring.

I changed the border color to be 1 step darker (100 -> 200) and set the text color to always be black.

![image](https://user-images.githubusercontent.com/112928/57399565-85339600-719f-11e9-90fa-d2747428bb62.png)
