### PR TITLE
Updated side-navigation to include descriptions

### DIFF
--- a/_includes/aip-nav.html
+++ b/_includes/aip-nav.html
@@ -1,4 +1,4 @@
-{% assign areas = 'apps,cloud' | split: ',' %}
+{% assign areas = 'apps:GSuite,cloud:Google Cloud Platform' | split: ',' %}
 {% assign scope = page.aip.scope or page.aip_index.scope %}
 <nav id="aip-nav" class="docs-component-nav">
   <ul class="nav-list">
@@ -6,12 +6,15 @@
     <li class="nav-item{% if page.url == '/' %} nav-item-active{% endif %}">
       <a href="/">General</a>
     </li>
-    {% for area in areas %}
+    {% for areaPairString in areas %}
+    {% assign areaPair = areaPairString | split: ':' %}
+    {% assign area = areaPair[0] %}
+    {% assign description = areaPair[1] %}
     {% if page.aip_index.scope == area %}
       {% assign scope = area %}
     {% endif %}
     <li class="nav-item{% if page.aip_index.scope == area %} nav-item-active{% endif %}">
-      <a href="/{{ area }}">{{ area | capitalize }}</a>
+      <a href="/{{ area }}">{{ description }}</a>
     </li>
     {% endfor %}
     <li class="nav-item nav-item-header">Tools</li>


### PR DESCRIPTION
I made it so that this list is a combination.

I did some research to see if this was just liquid being a really dumb language that can't take array or map literals. Turns out it can't. So here we are.

![image](https://user-images.githubusercontent.com/112928/57406003-c8950100-71ad-11e9-8124-94e474c056f7.png)
