### PR TITLE
Fixed types and added missing linkes for aip/214

### DIFF
--- a/aip/0214.md
+++ b/aip/0214.md
@@ -11,7 +11,7 @@ redirect_from:
 # Resource expiration
 
 Customers often want to provide the time that a given resource or attribute of
-a resource is no longer useful, or should be deleted. Currently we recommend
+a resource is no longer useful or should be deleted. Currently we recommend
 that customers do this by specifying an exact "expiration time" into a
 `google.protobuf.Timestamp expire_time` field; however, this adds additional
 strain on the user when they want to specify a relative time offset until
@@ -25,16 +25,16 @@ library.
 ## Guidance
 
 1.  APIs wishing to convey an expiration **must** rely on a
-    `google.protobuf.Timestamp` field called `expire_time`.
+    [`google.protobuf.Timestamp`][timestamp] field called `expire_time`.
 2.  APIs wishing to allow a relative expiration time must define a `oneof`
     called `expiration` (or `{something}_expiration`) containing both the
-    `expire_time` field and a separate `google.protobuf.Duration` field called
-    `ttl`, the latter marked as input only.
+    `expire_time` field and a separate [`google.protobuf.Duration`][duration]
+    field called `ttl`, the latter marked as input only.
 3.  APIs **must** always return the expiration time in the `expire_time` field
     and leave the `ttl` field blank when retrieving the resource.
 4.  APIs that rely on the specific semantics of a "time to live" (e.g., DNS
     which must represent the TTL as an integer) **may** use an `int64 ttl`
-    field (and **should** provide an [api.dev/not-precedent](./0200.md) comment
+    field (and **should** provide an [aip.dev/not-precedent](./0200.md) comment
     in this case).
 
 ### Example
@@ -76,3 +76,8 @@ the command-line and using REST/JSON. Leaving things as they are is typically
 the default, but it seems many customers want the ability to define relative
 expiration times as it is quite a bit easier and removes questions of time
 zones, stale clocks, and other silly mistakes.
+
+<!-- prettier-ignore-start -->
+[duration]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/duration.proto
+[timestamp]: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/timestamp.proto
+<!-- prettier-ignore-end -->


### PR DESCRIPTION
This does three things:

1. Remove an extra comma.
2. Adds links for the Timestamp and Duration protos.
3. Fixes a link typo.