### PR TITLE
[AIP-4232] Add AIP for method signatures / flattening.

### DIFF
--- a/aip/client-libraries/4232.md
+++ b/aip/client-libraries/4232.md
@@ -1,0 +1,87 @@
+---
+aip:
+  id: 4232
+  state: approved
+  created: 2018-06-22
+  updated: 2019-05-09
+permalink: /client-libraries/4232
+redirect_from:
+  - /4232
+---
+
+# Method signatures
+
+In protocol buffer RPCs, each RPC takes exactly one argument: a message.
+However, sending a full message structure can be cumbersome in the case of
+extremely simple requests.
+
+Many RPCs provide information about which pieces of the request are important
+and commonly used. In many languages, functions and methods take multiple
+positional or keyword arguments.
+
+## Guidance
+
+Some APIs provide annotations to hint how to effectively translate from a
+single request object to individual arguments, and client libraries **may**
+provide overloads based on these hints; however, client libraries implementing
+this feature **must** retain the default behavior of accepting the full request
+object. (Put another way, if an API _adds_ this annotation to an
+already-published API, the resulting library change **must** be
+backwards-compatible.)
+
+Client library generators **may** also choose to provide this functionality in
+some cases but not others, as appropriate in the environment. For example, it
+is permissible to provide an overload only if all arguments are primitives, or
+only if all arguments are required. The requirement that the request object is
+always accepted still applies.
+
+### Method Signatures
+
+An RPC with the [`google.api.method_signature`][method_signature] annotation
+indicates that an overload with a flattened method signature is desired where
+supported. The string contains comma-separated arguments, in order. If a
+field's name contains a period (`.`) character, this indicates a nested field.
+An RPC can provide this annotation more than once to specify multiple
+signatures (in order of importance/precedence).
+
+### Required Arguments
+
+Often, certain fields on the request message are consistently required, as
+described in [AIP-203][].
+
+While client libraries generally should not perform validation on this (that is
+the server's role), client libraries **may** distinguish required arguments in
+method signatures from optional ones if appropriate for the language. A field
+is considered required for this purpose if annotated with the
+`google.api.field_behavior` annotation value of `REQUIRED`:
+
+```proto
+message TranslateTextRequest {
+  // The text to translate.
+  string q = 1 [(google.api.field_behavior) = REQUIRED];
+}
+
+**Note:** The annotation for field behavior is attached to _the field_, not the
+method.
+
+### Restrictions
+
+If an RPC lists a nested field in
+[`google.api.method_signature`][method_signature] (for example,
+`"foo.bar.baz"`), none of the individual component fields may be repeated
+except for the last one (continuing the example, `baz` could be repeated but
+`foo` or `bar` could not be). Code generators implementing this feature
+**must** error with a descriptive error message if encountering a non-terminal
+repeated field as a field name.
+
+If any fields are required arguments, all required arguments are expected to
+appear before any optional ones. Code generators implementing this feature
+**should** error with a descriptive error message if encountering a required
+field after an optional one, and **must** do so if the resulting client library
+would not be valid.
+
+<!-- prettier-ignore-start -->
+[aip-203]: /aip/0203.md
+[method_signature]: https://github.com/googleapis/api-common-protos/blob/master/google/api/client.proto#L100
+<!-- prettier-ignore-end -->
+```

--- a/aip/client-libraries/4232.md
+++ b/aip/client-libraries/4232.md
@@ -23,17 +23,25 @@ positional or keyword arguments.
 
 Some APIs provide annotations to hint how to effectively translate from a
 single request object to individual arguments, and client libraries **may**
-provide overloads based on these hints; however, client libraries implementing
-this feature **must** retain the default behavior of accepting the full request
-object. (Put another way, if an API _adds_ this annotation to an
-already-published API, the resulting library change **must** be
-backwards-compatible.)
+provide overloads based on these hints.
+
+However, client libraries implementing this feature **must** retain the default
+behavior of accepting the full request object. Put another way, if an API
+_adds_ this annotation to an already-published API, the resulting library
+change **must** be backwards-compatible.
 
 Client library generators **may** also choose to provide this functionality in
-some cases but not others, as appropriate in the environment. For example, it
-is permissible to provide an overload only if all arguments are primitives, or
-only if all arguments are required. The requirement that the request object is
-always accepted still applies.
+some cases but not others, as appropriate in the environment. For example, any
+of the following strategies would be permissible:
+
+- Providing overloads iff all arguments in the signature are primitives.
+- Providing overloads iff all arguments in the signature are required.
+- Providing overloads only for the first of multiple signatures when providing
+  more than one would produce a conflict.
+- Any combination of the above.
+
+In all of these situations, the requirement that the request object is always
+accepted still applies.
 
 ### Method Signatures
 
@@ -41,8 +49,15 @@ An RPC with the [`google.api.method_signature`][method_signature] annotation
 indicates that an overload with a flattened method signature is desired where
 supported. The string contains comma-separated arguments, in order. If a
 field's name contains a period (`.`) character, this indicates a nested field.
+
 An RPC can provide this annotation more than once to specify multiple
-signatures (in order of importance/precedence).
+signatures. Order matters here: In some situations, it may not be possible to
+generate an overload for every signature provided. In this situation, client
+library generators **must** follow a "first match wins" strategy (generate an
+overload for the first signature in the conflict set, and drop the rest).
+
+**Note:** A corollary to this is that it is only guaranteed to be a
+backwards-compatible change to _append_ method signature annotations.
 
 ### Required Arguments
 
@@ -60,6 +75,7 @@ message TranslateTextRequest {
   // The text to translate.
   string q = 1 [(google.api.field_behavior) = REQUIRED];
 }
+```
 
 **Note:** The annotation for field behavior is attached to _the field_, not the
 method.
@@ -84,4 +100,3 @@ would not be valid.
 [aip-203]: /aip/0203.md
 [method_signature]: https://github.com/googleapis/api-common-protos/blob/master/google/api/client.proto#L100
 <!-- prettier-ignore-end -->
-```


### PR DESCRIPTION
This migrates the section on method signatures over to an AIP.