### PR TITLE
Fix #39: Made permalinks for AIPs use the AIP ID.

### DIFF
--- a/_includes/aip-summary.html
+++ b/_includes/aip-summary.html
@@ -10,8 +10,8 @@
   <tr>
     <td>Permalink</td>
     <td>
-      <a href="https://aip.dev{{ page.permalink }}">
-        aip.dev{{ page.permalink }}
+      <a href="https://aip.dev/{{ page.aip.id }}">
+        aip.dev/{{ page.aip.id }}
       </a>
     </td>
   </tr>


### PR DESCRIPTION
For example, AIP-2715 had a permalink of aip.dev/apps/2715. Now it has a link of aip.dev/2715 (which will ultimately redirect to aip.dev/apps/2715

In other words, I agree that the canonical name here should include the block name (apps, cloud, etc). However if we always refer to it that way, folks won't know that they can just do the number alone -- and that's important. Most people won't want to have to figure out what group the number is a part of -- they just want to say "show me AIP 1234", so that's the short-link we should be showing.