### PR TITLE
[feat] Improve the friendly names in navigation.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,10 @@ defaults:
   - scope:
       path: aip
     values:
+      areas:
+        apps: GSuite
+        cloud: Google Cloud Platform
+        client-libraries: Client Libraries
       js:
         - /assets/js/proto-syntax.js
   - scope:

--- a/_includes/aip-breadcrumb.html
+++ b/_includes/aip-breadcrumb.html
@@ -5,11 +5,11 @@
     </li>
     {% if page.aip %}
     <li class="h-c-breadcrumbs__item" aria-level="2">
-      <a
-        class="h-c-breadcrumbs__link"
-        href="/{{ page.aip.scope | default: '#aip-listing' }}"
-      >
-        {{ page.aip.scope | default: 'general' | capitalize }} AIPs
+      <!-- prettier-ignore -->
+      <a class="h-c-breadcrumbs__link"
+         href="/{{ page.aip.scope | default: '#aip-listing' }}">
+        {% if page.aip.scope %}{{ page.areas[page.aip.scope] }}
+        {% else %} General{% endif %} AIPs
       </a>
     </li>
     {% endif %}

--- a/_includes/aip-breadcrumb.html
+++ b/_includes/aip-breadcrumb.html
@@ -9,7 +9,7 @@
       <a class="h-c-breadcrumbs__link"
          href="/{{ page.aip.scope | default: '#aip-listing' }}">
         {% if page.aip.scope %}{{ page.areas[page.aip.scope] }}
-        {% else %} General{% endif %} AIPs
+        {% else %}General{% endif %} AIPs
       </a>
     </li>
     {% endif %}

--- a/_includes/aip-nav.html
+++ b/_includes/aip-nav.html
@@ -1,4 +1,3 @@
-{% assign areas = 'apps:GSuite,cloud:Google Cloud Platform' | split: ',' %}
 {% assign scope = page.aip.scope or page.aip_index.scope %}
 <nav id="aip-nav" class="docs-component-nav">
   <ul class="nav-list">
@@ -6,15 +5,12 @@
     <li class="nav-item{% if page.url == '/' %} nav-item-active{% endif %}">
       <a href="/">General</a>
     </li>
-    {% for areaPairString in areas %}
-    {% assign areaPair = areaPairString | split: ':' %}
-    {% assign area = areaPair[0] %}
-    {% assign description = areaPair[1] %}
-    {% if page.aip_index.scope == area %}
-      {% assign scope = area %}
+    {% for area in page.areas %}
+    {% if page.aip_index.scope == area[0] %}
+      {% assign scope = area[0] %}
     {% endif %}
-    <li class="nav-item{% if page.aip_index.scope == area %} nav-item-active{% endif %}">
-      <a href="/{{ area }}">{{ description }}</a>
+    <li class="nav-item{% if page.aip_index.scope == area[0] %} nav-item-active{% endif %}">
+      <a href="/{{ area[0] }}">{{ area[1] }}</a>
     </li>
     {% endfor %}
     <li class="nav-item nav-item-header">Tools</li>

--- a/_includes/aip-nav.html
+++ b/_includes/aip-nav.html
@@ -27,7 +27,7 @@
       </svg>
     </li>
     <li class="nav-item nav-item-header">
-      {{ scope | default: 'general' | capitalize }} AIPs
+      {% if scope %}{{ page.areas[scope] }}{% else %}General{% endif %} AIPs
     </li>
     {% for p in site.pages %}{% if p.aip and p.aip.scope == scope -%}
     <li class="nav-item{% if p.url == page.url %} nav-item-active{% endif %}">

--- a/_includes/aip-summary.html
+++ b/_includes/aip-summary.html
@@ -27,7 +27,7 @@
   {% if page.aip.scope -%}
   <tr>
     <td>Scope</td>
-    <td>{{ page.aip.scope | capitalize }}</td>
+    <td>{{ page.areas[page.aip.scope] }}</td>
   </tr>
   {% endif -%} {% if page.aip.state -%}
   <tr>

--- a/aip/client-libraries/4210.md
+++ b/aip/client-libraries/4210.md
@@ -1,7 +1,7 @@
 ---
 aip:
   id: 4210
-  scope: client libraries
+  scope: client-libraries
   state: reviewing
   created: 2018-06-22
   updated: 2019-04-18

--- a/aip/client-libraries/4231.md
+++ b/aip/client-libraries/4231.md
@@ -1,7 +1,7 @@
 ---
 aip:
   id: 4231
-  scope: client libraries
+  scope: client-libraries
   state: reviewing
   created: 2018-06-22
   updated: 2019-05-09

--- a/aip/client-libraries/4232.md
+++ b/aip/client-libraries/4232.md
@@ -1,6 +1,7 @@
 ---
 aip:
   id: 4232
+  scope: client-libraries
   state: approved
   created: 2018-06-22
   updated: 2019-05-09

--- a/aip/client-libraries/4233.md
+++ b/aip/client-libraries/4233.md
@@ -1,6 +1,7 @@
 ---
 aip:
   id: 4233
+  scope: client-libraries
   state: reviewing
   created: 2018-06-22
   updated: 2019-05-09

--- a/aip/client-libraries/index.md
+++ b/aip/client-libraries/index.md
@@ -1,13 +1,13 @@
 ---
 aip_index:
-  scope: client libraries
+  scope: client-libraries
 exclude_from_search: true
 js:
   - /assets/js/aip/aip-index.js
 permalink: /client-libraries
 ---
 
-# Client Library AIPs
+# Client Libraries AIPs
 
 The following AIPs apply to work on client libraries and generators for
 mass-producing client libraries.


### PR DESCRIPTION
This commit moves the PA friendly name definitions into `_config.yml`, and updates breadcrumbs and the summary boxes to use them.

This also gets rid of the parse-map-from-string-on-the-fly thing that was caused by lack of useful collection support in Liquid. Since we are using this in multiple files now, it makes sense for it to go to `_config.yml`.

Also changed the `client-libraries` scope to kebab-case since we are no longer using the scope name for display.

This builds on what @jgeewax did in #25 (making it happen everywhere).