### PR TITLE
[AIP-1] Squash editors and approvers, relax quorum.

### DIFF
--- a/aip/0001.md
+++ b/aip/0001.md
@@ -97,12 +97,6 @@ The list of AIP editors is currently:
 - Jon Skeet ([@jskeet][])
 - Luke Sneeringer ([@lukesneeringer][])
 
-Every AIP **must** be approved by, at minimum, the ATL-D with responsibility
-over the domain covered by the AIP (either design or infrastructure) and at
-least one other editor, with no editors actively requesting changes.
-Additionally, if an AIP editor is the primary author of an AIP, then at minimum
-two _other_ editors must approve it.
-
 The editors are also responsible for the administrative and editorial aspects
 of shepherding AIPs and managing the AIP pipeline and workflow. They approve
 PRs to AIPs, assign proposal numbers, manage the agenda, set AIP states, and so
@@ -144,9 +138,8 @@ proposal before moving forward.
 
 ### Approved
 
-Once an approved AIP has been implemented (which often means writing code to
-support the proposal), it enters "approved" state and is considered "best
-current practice".
+Once an approved AIP has been agreed upon, it enters "approved" state and is
+considered "best current practice".
 
 ### Withdrawn
 
@@ -207,49 +200,55 @@ digraph d_front_back {
 
 ### Proposing an AIP
 
-In order to propose an AIP, first circulate the fundamental idea for the AIP on
-api-design@google.com for initial feedback. It should generally be possible to
-describe the idea in a couple of pages. In most cases, it is best to circulate
-a traditional design doc to get initial comments.
+In order to propose an AIP, first [open an issue][] to circulate the
+fundamental idea for initial feedback. It should generally be possible to
+describe the idea in a couple of pages.
 
 Once ready, create a PR with a new file in the AIP directory using a file
-titled `new.md`. Assign @googleapis/aip-editors as the PR reviewer, and ensure
-that the PR is editable by maintainers.
+titled `aip/new.md`. Ensure that the PR is editable by maintainers.
 
 In most circumstances, the editors will assign the proposal an AIP number and
-submit the PR with the AIP in the "Draft" state. The editors may reject an AIP
-outright if they have an obvious reason to do so (e.g. the proposal was already
-discussed and rejected in another AIP or is fundamentally unsound), in which
-case the PR is not merged.
+submit the PR with the AIP in the "Reviewing" state. The editors may reject an
+AIP outright if they have an obvious reason to do so (e.g. the proposal was
+already discussed and rejected in another AIP or is fundamentally unsound), in
+which case the PR is not merged.
 
 ### Discussing an AIP
 
-Once the PR is submitted, the AIP author is responsible for championing the AIP
-on the api-design@google.com list. This means that the author is responsible
-for pushing towards consensus around the proposal. This may involve mailing
-list discussions as well as discussions at the regularly scheduled meetings for
-the API Governance team.
+Once the PR is merged, the AIP author is responsible for championing the AIP on
+a follow-up approval pull request. This means that the author is responsible
+for pushing towards consensus around the proposal. This may involve a
+discussion at the regularly scheduled meetings for the API Governance team.
 
 The AIP author may modify the AIP over the course of discussion by submitting
-follow-up PRs to the AIP.
+follow-up commits to the PR.
 
 ### Accepting an AIP
 
 The editors will work together to ensure that qualified proposals do not linger
-in review. Once an AIP is ready and there is a general consensus between
-stakeholders, the editors will vote to approve the AIP. If the AIP is approved
-by unanimous consent, the editors will update the state of the AIP to reflect
-this.
+in review.
+
+To gain final approval, an AIP **must** be approved by, at minimum, the ATL-D
+with responsibility over the domain covered by the AIP (either design or
+infrastructure) and at least one other editor, with no editors actively
+requesting changes.
+
+**Note:** If an AIP editor is the primary author of an AIP, then at least two
+_other_ editors must approve it.
+
+Once the AIP is approved, the editors will update the state of the AIP to
+reflect this and submit the PR.
 
 ### Withdrawing or Rejecting an AIP
 
 The author of an AIP may decide, after further consideration, that an AIP
-should not advance. If so, the author may withdraw the AIP by sending a PR
+should not advance. If so, the author may withdraw the AIP by updating the PR
 adding a notice of withdrawal with an explanation of the rationale.
 Additionally, the author may be unable to get consensus among the group and the
 AIP editors may elect to reject the AIP. In this situation, the AIP editors
-shall send a PR adding a notice of rejection with an explanation of the
-rationale. In both cases, the AIP editors shall update the state accordingly.
+shall amend the PR adding a notice of rejection with an explanation of the
+rationale. In both cases, the AIP editors update the state accordingly and
+submit the PR.
 
 ### Replacing an AIP
 
@@ -269,6 +268,7 @@ state, and will link to the new, current AIP.
 
 [aip-2]: ./0002.md
 [aip github repository]: https://github.com/googleapis/aip
+[open an issue]: https://github.com/googleapis/aip/issues
 [@jgeewax]: https://github.com/jgeewax
 [@jskeet]: https://github.com/jskeet
 [@lukesneeringer]: https://github.com/lukesneeringer

--- a/aip/0001.md
+++ b/aip/0001.md
@@ -60,12 +60,16 @@ digraph d_front_back {
   rankdir=BT;
   ranksep=0.3;
   node [ style="filled,solid" shape=box fontname="Roboto" ];
+
   producer [ label="API Producer" ];
   editors [ label="AIP Editors" ];
-  approvers [ label="AIP Approvers" ];
-  atld [ label="ATL-D" ];
+  atld_infra [ label="ATL-D\n(Infrastructure)" ];
+  atld_design [ label="ATL-D\n(Design)" ];
   atl [ label="ATL" ];
-  producer -> editors -> approvers -> atld -> atl;
+
+  producer -> editors;
+  editors -> atld_infra -> atl;
+  editors -> atld_design -> atl;
 }
 ```
 
@@ -73,41 +77,39 @@ digraph d_front_back {
 
 The current ATL (area technical lead) for APIs at Google is Eric Brewer; he has
 delegated ATL responsibilities ("ATL-D") for API Infrastructure to Hong Zhang
-(@wora) and API Design to JJ Geewax (@jgeewax). This document uses ATL and
-ATL-D consistently to refer to this role.
+([@wora][]) and API Design to JJ Geewax ([@jgeewax][]). This document uses ATL
+and ATL-D consistently to refer to this role.
 
 As noted in the diagram above, the ATL is the final decision-maker on the AIP
 process and the point of escalation if necessary.
 
-### Approvers
-
-The approvers are the set of people who make decisions on AIPs. The general
-goal is that the AIP process is collaborative and that we largely work on the
-basis of consensus. However, a limited number of designated approvers is
-necessary, and these Googlers will be approvers for each AIP.
-
-The list of AIP approvers is currently:
-
-- Hong Zhang (@wora)
-- JJ Geewax (@jgeewax)
-- Jon Skeet (@jskeet)
-
-AIP approvership is by invitation of the current approvers.
-
 ### Editors
 
-The editors are those responsible for the administrative and editorial aspects
+The editors are the set of people who make decisions on AIPs. The general goal
+is that the AIP process is collaborative and that we largely work on the basis
+of consensus. However, a limited number of designated approvers is necessary,
+and these Googlers will be approvers for each AIP in the general scope.
+
+The list of AIP editors is currently:
+
+- Hong Zhang ([@wora][])
+- JJ Geewax ([@jgeewax][])
+- Jon Skeet ([@jskeet][])
+- Luke Sneeringer ([@lukesneeringer][])
+
+Every AIP **must** be approved by, at minimum, the ATL-D with responsibility
+over the domain covered by the AIP (either design or infrastructure) and at
+least one other editor, with no editors actively requesting changes.
+Additionally, if an AIP editor is the primary author of an AIP, then at minimum
+two _other_ editors must approve it.
+
+The editors are also responsible for the administrative and editorial aspects
 of shepherding AIPs and managing the AIP pipeline and workflow. They approve
 PRs to AIPs, assign proposal numbers, manage the agenda, set AIP states, and so
 forth. They also ensure that AIPs are readable (proper spelling, grammar,
 sentence structure, markup, etc.).
 
-AIP approvers are all considered to be editors. The list of additional AIP
-editors is currently:
-
-- Luke Sneeringer (@lukesneeringer)
-
-AIP editorship is by invitation of the current approvers.
+AIP editorship is by invitation of the current editors.
 
 ## Domain-specific AIPs
 
@@ -125,7 +127,7 @@ through the process. The following is a summary of each state.
 
 The initial state for an AIP is the "Draft" state. This means that the AIP is
 being discussed and iterated upon, primarily by the original authors. While the
-editors and approvers _may_ get involved at this stage, it is not necessary.
+editors _may_ get involved at this stage, it is not necessary.
 
 **Note:** If significant, high-level iteration is required, it is recommended
 to draft AIPs in a Google doc instead of a PR. AIPs that are migrated into the
@@ -136,8 +138,8 @@ reviewing.
 
 Once discussion on an AIP has generally concluded, but before it is formally
 accepted it moves to the "Reviewing" state. This means that the authors have
-reached a general consensus on the proposal and the approvers are now involved.
-At this stage the approvers may request changes or suggest alternatives to the
+reached a general consensus on the proposal and the editors are now involved.
+At this stage the editors may request changes or suggest alternatives to the
 proposal before moving forward.
 
 ### Approved
@@ -153,9 +155,9 @@ AIPs that are withdrawn may be taken up by another champion.
 
 ### Rejected
 
-If an AIP is rejected by the AIP approvers, it enters "rejected" state. AIPs
-that are rejected remain, and provide documentation and reference to inform
-future discussions.
+If an AIP is rejected by the AIP editors, it enters "rejected" state. AIPs that
+are rejected remain, and provide documentation and reference to inform future
+discussions.
 
 ### Deferred
 
@@ -233,11 +235,11 @@ follow-up PRs to the AIP.
 
 ### Accepting an AIP
 
-The approvers and editors will work together to ensure that qualified proposals
-do not linger in review. Once an AIP is ready and there is a general consensus
-between stakeholders, the approvers will vote to approve the AIP. If the AIP is
-approved by unanimous consent, the editors will update the state of the AIP to
-reflect this.
+The editors will work together to ensure that qualified proposals do not linger
+in review. Once an AIP is ready and there is a general consensus between
+stakeholders, the editors will vote to approve the AIP. If the AIP is approved
+by unanimous consent, the editors will update the state of the AIP to reflect
+this.
 
 ### Withdrawing or Rejecting an AIP
 
@@ -245,10 +247,9 @@ The author of an AIP may decide, after further consideration, that an AIP
 should not advance. If so, the author may withdraw the AIP by sending a PR
 adding a notice of withdrawal with an explanation of the rationale.
 Additionally, the author may be unable to get consensus among the group and the
-AIP approvers may elect to reject the AIP. In this situation, the AIP approvers
-or editors shall send a PR adding a notice of rejection with an explanation of
-the rationale. In both cases, the AIP editors shall update the state
-accordingly.
+AIP editors may elect to reject the AIP. In this situation, the AIP editors
+shall send a PR adding a notice of rejection with an explanation of the
+rationale. In both cases, the AIP editors shall update the state accordingly.
 
 ### Replacing an AIP
 
@@ -261,8 +262,14 @@ state, and will link to the new, current AIP.
 
 ## Changelog
 
+- **2019-05-12**: Collapsed AIP approvers and editors into a single position,
+  relaxed approval rules from full quorum.
 - **2019-05-04**: Updated the AIP to refer to GitHub processes, rather than
   internal processes.
 
 [aip-2]: ./0002.md
 [aip github repository]: https://github.com/googleapis/aip
+[@jgeewax]: https://github.com/jgeewax
+[@jskeet]: https://github.com/jskeet
+[@lukesneeringer]: https://github.com/lukesneeringer
+[@wora]: https://github.com/wora


### PR DESCRIPTION
This commit makes a couple changes that I discussed with @jgeewax
late last week:

- Squashes "editor" and "approver" into a single position.
- Relaxes the quorum requirement to "the appropriate ATL-D plus one"
  (with no active changes requested).