### PR TITLE
[AIP-4222] Fix a scope header.

### DIFF
--- a/aip/client-libraries/4222.md
+++ b/aip/client-libraries/4222.md
@@ -1,6 +1,7 @@
 ---
 aip:
   id: 4222
+  scope: client-libraries
   state: reviewing
   created: 2018-06-22
   updated: 2019-05-09


### PR DESCRIPTION
I derped and forgot to add `scope: client-libraries` and so AIP-4222 showed up in the wrong menu.