### PR TITLE
Add note that page token must be validated

### DIFF
--- a/aip/general/0158.md
+++ b/aip/general/0158.md
@@ -105,8 +105,9 @@ proto, base-64 encoded.
 
 Page tokens **must** be limited to providing an indication of where to continue
 the pagination process only. They **must not** provide any form of authorization
-to the underlying resources, and authorization must be performed on the request as
-with any other regardless of the presence of a page token.
+to the underlying resources, and authorization **must** be performed on the request
+as with any other regardless of the presence of a page token.
+
 ### Expiring page tokens
 
 Many APIs store page tokens in a database internally. In this situation, APIs

--- a/aip/general/0158.md
+++ b/aip/general/0158.md
@@ -103,6 +103,10 @@ contain sensitive data, an API **may** obfuscate the page token by defining an
 internal protocol buffer message with any data needed, and send the serialized
 proto, base-64 encoded.
 
+Even with obfuscation protection, the page token might still be modified by a
+caller. The service **must** validate the contents of the page token and authenticate
+the caller for any access to resources specified in the page token.
+
 ### Expiring page tokens
 
 Many APIs store page tokens in a database internally. In this situation, APIs

--- a/aip/general/0158.md
+++ b/aip/general/0158.md
@@ -103,10 +103,10 @@ contain sensitive data, an API **may** obfuscate the page token by defining an
 internal protocol buffer message with any data needed, and send the serialized
 proto, base-64 encoded.
 
-Even with obfuscation protection, the page token might still be modified by a
-caller. The service **must** validate the contents of the page token and authenticate
-the caller for any access to resources specified in the page token.
-
+Page tokens **must** be limited to providing an indication of where to continue
+the pagination process only. They **must not** provide any form of authorization
+to the underlying resources, and authorization must be performed on the request as
+with any other regardless of the presence of a page token.
 ### Expiring page tokens
 
 Many APIs store page tokens in a database internally. In this situation, APIs


### PR DESCRIPTION
The page token should not be treated as trusted input. It should be validated and any access to resources specified in the page token should be authenticated. That is, the page token should not be trusted as proving an earlier authentication occurred.