### PR TITLE
FIX(AIP-157): clarify distinction between request and request message

### DIFF
--- a/aip/general/0157.md
+++ b/aip/general/0157.md
@@ -19,16 +19,15 @@ APIs **may** support partial responses in one of two ways:
 ### Field masks parameter
 
 Field masks (`google.protobuf.FieldMask`) can be used for granting the user
-fine-grained control over what fields are returned. An API **should** support the mask in a side channel.
-For example, the parameter can be specified either using an HTTP query
+fine-grained control over what fields are returned. An API **should** support the mask being specified
+in a side channel. For example, the parameter can be specified either using an HTTP query
 parameter, an HTTP header, or a [gRPC metadata entry][1]. Google Cloud APIs specify field masks as a [system parameter][0].
 
-Field masks **should not** be specified in the [request](./0157.md#read-masks-as-a-request-field).
+Field masks **should not** be specified as a field on the [request message](./0157.md#read-masks-as-a-request-field).
 
-- The value of the field mask parameter **must** be a `google.protobuf.FieldMask`.
+- The value of the field mask parameter **must** be interpreted as a repeated `google.protobuf.FieldMask`.
 - The field mask parameter **must** be optional:
-  - An explicit value of `"*"` **should** be supported, and **must** return all
-    fields.
+  - An explicit value of `"*"` **should** be supported, and **must** return all fields.
   - If the field mask parameter is omitted, it **must** default to `"*"`, unless otherwise documented.
 - An API **may** allow read masks with non-terminal repeated fields (unlike
   update masks), but is not obligated to do so.


### PR DESCRIPTION
"should not be specified in the request" is ambiguous; side channels and headers are part of the request, as is the request message. This change clarifies the AIP to refer specifically to the request message, not the entire request.

Other phrasing in this AIP used "field on the request", not "field in the request", so this change is consistent with that.

This change includes further trivial tweaks to whitespace and grammar that should not change the intent.

The most important change here IMHO is the 1 word change (addition of "message") in L26. I opted to include further "trivial cleanup" but I don't feel strongly about it and please let me know if it's a bad idea to combine multiple purposes in one change like this. The change at L28 (from "must be a FieldMask" to "must be interpreted as a FieldMask") is because I found it confusing to talk about the type of the field-mask parameter when it's carried in a side channel (for most of the side channels there's no option to provide type information as part of the API definition, and I found talking about the type of the parameter to unintentionally imply it belongs in the API definition somewhere, eg as a request message field which is explicitly discouraged).