### PR TITLE
fix: Update 0194.md

### DIFF
--- a/aip/general/0194.md
+++ b/aip/general/0194.md
@@ -28,6 +28,7 @@ Clients **should not** automatically retry requests in which repeated runs
 would cause unintended state changes.
 
 **Note:** This AIP does not cover client streaming or bi-directional streaming.
+
 **Note:** Client side retry behavior for the client libraries is found in [AIP-4221](../client-libraries/4221).
 
 ### Retryable codes

--- a/aip/general/0194.md
+++ b/aip/general/0194.md
@@ -28,7 +28,7 @@ Clients **should not** automatically retry requests in which repeated runs
 would cause unintended state changes.
 
 **Note:** This AIP does not cover client streaming or bi-directional streaming.
-**Note:** Client side retry behavior for the client libraries is found in [AIP-4221](../client-libraries/4221.md).
+**Note:** Client side retry behavior for the client libraries is found in [AIP-4221](../client-libraries/4221).
 
 ### Retryable codes
 

--- a/aip/general/0194.md
+++ b/aip/general/0194.md
@@ -29,7 +29,7 @@ would cause unintended state changes.
 
 **Note:** This AIP does not cover client streaming or bi-directional streaming.
 
-**Note:** Client side retry behavior for the client libraries is found in [AIP-4221](../client-libraries/4221).
+**Note:** For client side retry behavior in the client libraries: see AIP-4221.
 
 ### Retryable codes
 


### PR DESCRIPTION
Oh no! Sorry about this @noahdietz and @toumorokoshi  - I got bamboozled in #1177 by the GitHub preview not being quite the same as the web view. If there's a way for me to see a staged view so this doesn't happen again, let me know so I make sure I don't waste your time if I make edits in the future!

The fixes:  
- the .md gives a 404! I believe this is the correct link - it should then become https://google.aip.dev/client-libraries/4221 when it's expanded. 
- I wanted to call out also that these two notes are appearing in the same box so I added a blank line to try to get them to appear in separate boxes, but we can revert that if you want. 

![image](https://github.com/aip-dev/google.aip.dev/assets/6719667/2d2271a7-2946-446d-8e56-3bbabaffc173)
