### PR TITLE
fix(AIP-203): disallow field_behavior in oneof

### DIFF
--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -25,7 +25,8 @@ RecognitionAudio audio = 2 [(google.api.field_behavior) = REQUIRED];
 ```
 
 - APIs **must** apply the `google.api.field_behavior` annotation on every field
-  on a message or sub-message used in a request.
+  on a message or sub-message used in a request, except for fields in a `oneof`.
+  - Fields within a `oneof` **must not** use `google.api.field_behavior`.
 - The annotation **must** include any [google.api.FieldBehavior][] values that
   accurately describe the behavior of the field.
   - `FIELD_BEHAVIOR_UNSPECIFIED` **must not** be used.


### PR DESCRIPTION
Disallow the use of `google.api.field_beahvior` on fields in a `oneof`. Even the `immutable`, `output_only`, etc. would be redundant and/or confusing if applied to every field (consistently or otherwise). Instead we should explore defining a `google.api.oneof_behavior` annotation to mimic `field_behavior` but for the entire group of oneof fields. That is a separate issue though.

Fixes #1156