### PR TITLE
feat(AIP-203): Clarify that IDENTIFIER fields must not use other behaviors

### DIFF
--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -289,6 +289,8 @@ surpass the costs to clients and API users of not doing so.
 
 ## Changelog
 
+- **2024-02-16**: `IDENTIFIER` annotations are mutually exclusive with all
+  other field behaviors. 
 - **2023-09-14**: Clarify that nested behavior and parent behavior are
   independent.
 - **2023-08-25**: Add guidance on `IDENTIFIER`.

--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -29,7 +29,8 @@ RecognitionAudio audio = 2 [(google.api.field_behavior) = REQUIRED];
 - The annotation **must** include any [google.api.FieldBehavior][] values that
   accurately describe the behavior of the field.
   - `FIELD_BEHAVIOR_UNSPECIFIED` **must not** be used.
-- APIs **must** at minimum use one of `REQUIRED`, `OPTIONAL`, or `OUTPUT_ONLY`.
+- APIs **must** at minimum use one of `REQUIRED`, `OPTIONAL`, `OUTPUT_ONLY` or
+  `IDENTIFIER`.
 
 **Warning:** Although `field_behavior` does not impact proto-level behavior,
 many clients (e.g. CLIs and SDKs) rely on them to generate code. Thoroughly
@@ -77,6 +78,9 @@ resource as the primary input e.g. [Standard Update][aip-134].
 
 This annotation **must not** be applied to references to other resources within
 a message.
+
+Fields annonated with `IDENTIFIER` **must not** use any other
+`google.api.field_behavior` annotation.
 
 ### Immutable
 


### PR DESCRIPTION
Fields marked as `IDENTIFIER` must not use other annotations, as they are either already implied or are mutually exclusive:

- `IMMUTABLE`: Implicit
- `INPUT_ONLY`: False, `IDENTIFIER` must be part of resource responses
- `OPTIONAL`: False, field is required on `Create`
- `OUTPUT_ONLY`: False, field is user-specified on `Create`
- `REQUIRED`: Implicit
- `UNORDERED_LIST`: Mutually exclusive, since `IDENTIFIER` fields **must** be of type `string`