### PR TITLE
fix(AIP-165): explicitly allow filter wildcard

### DIFF
--- a/aip/general/0165.md
+++ b/aip/general/0165.md
@@ -88,6 +88,7 @@ message PurgeBooksRequest {
 - A singular `string filter` field **must** be included and **must** follow the
   same semantics as in List methods (AIP-160).
   - It **should** be [annotated as required][aip-203].
+  - A wildcard value of `"*"` **may** be supported for deleting everything.
 - A singular `bool force` field **must** be included. If it is not set, the API
   **must** return a count of the resources that would be deleted as well as a
   sample of those resources, without actually performing the deletion.
@@ -132,6 +133,7 @@ message PurgeBooksResponse {
 
 ## Changelog
 
+- **2025-07-23:** Explicitly state filter wildcard may be supported.
 - **2022-06-02:** Changed suffix descriptions to eliminate superfluous "-".
 - **2020-10-29**: Expanded guidance on HTTP, field behavior, and resource
   reference annotations.


### PR DESCRIPTION
Since the `filter` field for `Purge` requests are `REQUIRED`, an empty string is not allowed, which means a specific value for indicating "delete everything" is necessary. We already have this pattern in parts of AIP-160 where support for `"*"` as a  wildcard is allowed. Make that explicit here.

Internal bug http://b/431251818