### PR TITLE
Update 0160.md

### DIFF
--- a/aip/general/0160.md
+++ b/aip/general/0160.md
@@ -169,11 +169,11 @@ filters.
 Maps, structs, messages can query either for the presence of a field in the map
 or a specific value:
 
-| Example    | Meaning                             |
-| ---------- | ----------------------------------- |
-| `m:foo`    | True if `m` contains the key "foo". |
-| `m.foo:*`  | True if `m` contains the key "foo". |
-| `m.foo:42` | True if `m.foo` is 42.              |
+| Example    | Meaning                                                        |
+| ---------- | -------------------------------------------------------------- |
+| `m:foo`    | True if `m` contains the key "foo".                            |
+| `m.foo:*`  | True if `m` contains the key "foo" and the value is not empty. |
+| `m.foo:42` | True if `m.foo` is 42.                                         |
 
 There are two slight distinctions when parsing messages:
 


### PR DESCRIPTION
Intuitively this seems like a necessary condition for this to return true.

If `m` contains the key `foo` but the value of `foo` in the map is null, I don't think this should return true.  A user looking to check that `foo` exists in the map should use the `m:foo` form, while `*` is checking for non-empty values