### PR TITLE
fix(AIP-140): explicitly call out units using abbreviations

### DIFF
--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -207,6 +207,7 @@ creating a more coherent surface. At the same time, the requirement being a
 
 ## Changelog
 
+- **2025-10-23**: Call out AIP-141 unit abbreviations as preferred.
 - **2025-03-10**: Add rationale for URI guidance.
 - **2024-12-20**: Copy over abbreviations guidance from old design site.
 - **2024-08-26**: Codify exception to string and base64 guidance 

--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -93,6 +93,12 @@ Examples:
 - `spec` (**not** `specification`)
 - `stats` (**not** `statistics`)
 
+Furthermore, well known abbreviations for units **should** be used in field names.
+ See [AIP-141][] for more guidance on fields that represent quantities. Examples:
+
+- `distance_km` (**not** `distance_kilometers`)
+- `width_px` (**not** `width_pixels`)
+
 ### Adjectives
 
 For uniformity, field names that contain both a noun and an adjective

--- a/aip/general/0140.md
+++ b/aip/general/0140.md
@@ -94,7 +94,7 @@ Examples:
 - `stats` (**not** `statistics`)
 
 Furthermore, well known abbreviations for units **should** be used in field names.
- See [AIP-141][] for more guidance on fields that represent quantities. Examples:
+See [AIP-141][] for more guidance on fields that represent quantities. Examples:
 
 - `distance_km` (**not** `distance_kilometers`)
 - `width_px` (**not** `width_pixels`)


### PR DESCRIPTION
Explicitly call out that units in field names can/should be abbreviated as per AIP-141.

Internal bug report http://b/454631303