### PR TITLE
chore(AIP-134): fix broken AIP-151 and AIP-157 links

### DIFF
--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -160,7 +160,7 @@ wiped out data because the previous version did not know about it.
 
 Some resources take longer to update a resource than is reasonable for a
 regular API request. In this situation, the API **should** use a long-running
-operation [AIP-151][] instead:
+operation ([AIP-151][]) instead:
 
 ```proto
 rpc UpdateBook(UpdateBookRequest) returns (google.longrunning.Operation) {

--- a/aip/general/0134.md
+++ b/aip/general/0134.md
@@ -160,7 +160,7 @@ wiped out data because the previous version did not know about it.
 
 Some resources take longer to update a resource than is reasonable for a
 regular API request. In this situation, the API **should** use a long-running
-operation (AIP-151) instead:
+operation [AIP-151][] instead:
 
 ```proto
 rpc UpdateBook(UpdateBookRequest) returns (google.longrunning.Operation) {
@@ -291,8 +291,9 @@ does not exist, the service **must** error with `NOT_FOUND` (HTTP 404) unless
 
 [aip-121]: ./0121.md
 [aip-128]: ./0128.md
+[aip-151]: ./0151.md
+[aip-157]: ./0157.md
 [aip-203]: ./0203.md
-[create]: ./0133.md
 [errors]: ./0193.md
 [management plane]: ./0111.md#management-plane
 [permission-denied]: ./0193.md#permission-denied


### PR DESCRIPTION
This PR fixes broken link references in AIP-134:

- Added missing link definition for `[AIP-151][]` (referenced on line 163)
- Added missing link definition for `[AIP-157][]` (referenced on line 47)
- Removed unused `[create]` link reference definition