### PR TITLE
fix(AIP-164): mutations return failed_precondition

### DIFF
--- a/aip/general/0164.md
+++ b/aip/general/0164.md
@@ -111,6 +111,12 @@ purging those resources, including automatic purging after a reasonable time
 the resources indefinitely. Regardless of what strategy is selected, the API
 **should** document when soft deleted resources will be completely removed.
 
+### Mutations
+
+Soft-deleted resources **should not** be mutable and mutating methods **should**
+return a `FAILED_PRECONDITION` error. This applies to Standard Update
+(AIP-134) and mutating custom methods (AIP-136).
+
 ### Declarative-friendly resources
 
 Soft-deletable resources have a poorer experience than hard-deleted resources in
@@ -148,6 +154,7 @@ resource is not deleted, the service **must** respond with `ALREADY_EXISTS`
 
 ## Changelog
 
+- **2025-11-18**: Include expected behavior of mutating soft-deleted resource.
 - **2024-09-24**: Included missing requirement for `delete_time`.
 - **2023-07-13**: Renamed overloaded `expire_time` to `purge_time`.
 - **2021-07-12**: Added error behavior when soft deleting a deleted resource.


### PR DESCRIPTION
Based on https://github.com/aip-dev/google.aip.dev/issues/723#issuecomment-831554894 and discussion with what we have implemented, attempted mutations of a soft-deleted resource should return `FAILED_PRECONDITION` error.

Fixes #723 