### PR TITLE
Add CI workflow for Docker image build

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build the Docker image
+      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for building Docker images when changes are pushed to or pull requests are opened against the `master` branch. The workflow automates the Docker build process in CI.

Continuous integration setup:

* Added `.github/workflows/docker-image.yml` to define a workflow that triggers on pushes and pull requests to the `master` branch and builds the Docker image using the provided `Dockerfile`.