### PR TITLE
fix(AIP-214): update expire_time comment

### DIFF
--- a/aip/general/0214.md
+++ b/aip/general/0214.md
@@ -44,8 +44,8 @@ message ExpiringResource {
 
   oneof expiration {
     // Timestamp in UTC of when this resource is considered expired.
-    // This is *always* provided on output, regardless of what was sent
-    // on input.
+    // This is *always* provided on output, and is calculated using
+    // the value of [ttl][] if set when created.
     google.protobuf.Timestamp expire_time = 2;
 
     // Input only. The TTL for this resource.


### PR DESCRIPTION
Suggest a more explicit/useful comment for `expire_time` field as it relates to the `ttl` in the `oneof`.