### PR TITLE
typo: Remove unexpected space in markdown link

### DIFF
--- a/aip/general/0180.md
+++ b/aip/general/0180.md
@@ -122,8 +122,8 @@ breaking way.
 
 APIs **should** avoid increasing the upper bound for the size or limit (if
 accepted as input) of `string` fields. APIs **should** treat expected size upper
-bound increases as incompatible changes (see [Changing resource names]
-(#changing-resource-names) as an example). APIs **may** pad out values with
+bound increases as incompatible changes (see [Changing resource
+names](#changing-resource-names) as an example). APIs **may** pad out values with
 filler characters if reserving a consistent size is necessary, but this **must**
 be documented if done.
 


### PR DESCRIPTION
`[a] (b)` is not a valid link syntax regardless of space kind between components. `[a](b)` is