### PR TITLE
feat(AIP-4120): SPIFFE as a First-Class ADC External Credential Source

### DIFF
--- a/aip/auth/4120.md
+++ b/aip/auth/4120.md
@@ -1,0 +1,74 @@
+---
+id: 4120
+scope: auth
+state: draft
+created: 2026-04-03
+---
+
+# SPIFFE as a First-Class ADC External Credential Source
+
+This AIP describes native support for fetching external credentials from the
+SPIFFE Workload API. It extends [AIP-4117][] with an additional type of **credential_source**.
+
+## SPIFFE External Credentials
+
+The auth libraries **must** support the following additional credential source:
+
+| Field Name  | Required | Description                                                                                                                                                                               |
+| ----------- | -------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| spiffe      | Yes      | Presence of this property indicates that the SPIFFE Workload API should be used to fetch credentials from.                                                                                |
+| spiffe.type | Yes      | This indicates whether the JWT-SVIDs or X509-SVIDs should be presented to the STS and depends on the configuration of the workload identity pool provider. Allowed values: "jwt", "x509". |
+| spiffe.hint | No       | [Hint][0] for fetching the SVID. If a workload is entitled to multiple identities, this parameter can be used to select an identity.                                                      |
+
+Exemplary JSON ADC files:
+
+```json
+{
+  "universe_domain": "googleapis.com",
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/<project-number>/locations/global/workloadIdentityPools/<pool>/providers/<provider>",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "credential_source": {
+    "spiffe": {
+      "type": "jwt",
+      "hint": "external-gcp"
+    }
+  }
+}
+```
+
+```json
+{
+  "universe_domain": "googleapis.com",
+  "type": "external_account",
+  "audience": "//iam.googleapis.com/projects/<project-number>/locations/global/workloadIdentityPools/<pool>/providers/<provider>",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:mtls",
+  "token_url": "https://sts.mtls.googleapis.com/v1/token",
+  "credential_source": {
+    "spiffe": {
+      "type": "x509"
+    }
+  }
+}
+```
+
+The **spiffe** field is mutually exclusive with any other supported credential source (e.g. **file**, **url**, **executable** etc.).
+
+## Retrieval Semantics
+
+For **jwt**, auth clients **must** fetch the JWT using the **FetchJWTSVID** RPC from the [SPIFFE Workload API][1] and use the first returned JWT-SVID. For **x509**, auth clients **must** query the **FetchX509SVID** RPC and present the first of the returned X509-SVIDs to the STS. Clients **must** not try to validate the presented STS server certificate against the SPIFFE trust bundle. As such, clients **should** close the response stream once a valid X509-SVID has been fetched, since no further trust bundle updates are necessary.
+
+If the Workload API responds with the gRPC code **PermissionDenied** (i.e. no available identity), auth clients **may** retry the request.
+
+The implementation **must** adhere to the guidelines presented in the [SPIFFE Workload Endpoint][2] specification, such as respecting **SPIFFE_ENDPOINT_SOCKET**.
+
+## Future Work
+
+- In a future in which the Google Cloud Platform natively supports [SPIFFE Federation][3], the **type** parameter may become obsolete for auth clients to transparently switch between JWT/X.509 depending on the GCP implementation.
+
+[AIP-4117]: ./4117.md
+[0]: https://spiffe.io/docs/latest/spiffe-specs/spiffe_workload_api/#621-fetchjwtsvid
+[1]: https://github.com/spiffe/spiffe/blob/main/standards/workloadapi.proto
+[2]: https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Workload_Endpoint.md
+[3]: https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md

--- a/aip/auth/4120.md
+++ b/aip/auth/4120.md
@@ -14,11 +14,10 @@ SPIFFE Workload API. It extends [AIP-4117][] with an additional type of **creden
 
 The auth libraries **must** support the following additional credential source:
 
-| Field Name  | Required | Description                                                                                                                                                                               |
-| ----------- | -------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| spiffe      | Yes      | Presence of this property indicates that the SPIFFE Workload API should be used to fetch credentials from.                                                                                |
-| spiffe.type | Yes      | This indicates whether the JWT-SVIDs or X509-SVIDs should be presented to the STS and depends on the configuration of the workload identity pool provider. Allowed values: "jwt", "x509". |
-| spiffe.hint | No       | [Hint][0] for fetching the SVID. If a workload is entitled to multiple identities, this parameter can be used to select an identity.                                                      |
+| Field Name  | Required | Description                                                                                                                          |
+| ----------- | -------- | :----------------------------------------------------------------------------------------------------------------------------------- |
+| spiffe      | Yes      | Presence of this property indicates that the SPIFFE Workload API should be used to fetch credentials from.                           |
+| spiffe.hint | No       | [Hint][0] for fetching the SVID. If a workload is entitled to multiple identities, this parameter can be used to select an identity. |
 
 Exemplary JSON ADC files:
 
@@ -31,7 +30,6 @@ Exemplary JSON ADC files:
   "token_url": "https://sts.googleapis.com/v1/token",
   "credential_source": {
     "spiffe": {
-      "type": "jwt",
       "hint": "external-gcp"
     }
   }
@@ -46,9 +44,7 @@ Exemplary JSON ADC files:
   "subject_token_type": "urn:ietf:params:oauth:token-type:mtls",
   "token_url": "https://sts.mtls.googleapis.com/v1/token",
   "credential_source": {
-    "spiffe": {
-      "type": "x509"
-    }
+    "spiffe": {}
   }
 }
 ```
@@ -57,18 +53,14 @@ The **spiffe** field is mutually exclusive with any other supported credential s
 
 ## Retrieval Semantics
 
-For **jwt**, auth clients **must** fetch the JWT using the **FetchJWTSVID** RPC from the [SPIFFE Workload API][1] and use the first returned JWT-SVID. For **x509**, auth clients **must** query the **FetchX509SVID** RPC and present the first of the returned X509-SVIDs to the STS. Clients **must** not try to validate the presented STS server certificate against the SPIFFE trust bundle. As such, clients **should** close the response stream once a valid X509-SVID has been fetched, since no further trust bundle updates are necessary.
+If the **subject_token_type** parameter is **urn:ietf:params:oauth:token-type:jwt**, auth clients **must** fetch the JWT using the **FetchJWTSVID** RPC from the [SPIFFE Workload API][1] and use the first returned JWT-SVID. For **urn:ietf:params:oauth:token-type:mtls**, auth clients **must** query the **FetchX509SVID** RPC and present the first of the returned X509-SVIDs to the STS. Clients **must** not try to validate the presented STS server certificate against the SPIFFE trust bundle. As such, clients **should** close the response stream once a valid X509-SVID has been fetched, since no further trust bundle updates are necessary.
 
 If the Workload API responds with the gRPC code **PermissionDenied** (i.e. no available identity), auth clients **may** retry the request.
 
 The implementation **must** adhere to the guidelines presented in the [SPIFFE Workload Endpoint][2] specification, such as respecting **SPIFFE_ENDPOINT_SOCKET**.
 
-## Future Work
-
-- In a future in which the Google Cloud Platform natively supports [SPIFFE Federation][3], the **type** parameter may become obsolete for auth clients to transparently switch between JWT/X.509 depending on the GCP implementation.
 
 [AIP-4117]: ./4117.md
 [0]: https://spiffe.io/docs/latest/spiffe-specs/spiffe_workload_api/#621-fetchjwtsvid
 [1]: https://github.com/spiffe/spiffe/blob/main/standards/workloadapi.proto
 [2]: https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Workload_Endpoint.md
-[3]: https://github.com/spiffe/spiffe/blob/main/standards/SPIFFE_Federation.md

--- a/aip/auth/4120.md
+++ b/aip/auth/4120.md
@@ -53,7 +53,7 @@ Exemplary JSON ADC files:
 }
 ```
 
-The **spiffe** field is mutually exclusive with any other supported credential source (e.g. **file**, **url**, **executable** etc.).
+The **spiffe** field is mutually exclusive with any other supported credential source (e.g. **file**, **url**, **executable**, etc.).
 
 ## Retrieval Semantics
 


### PR DESCRIPTION
(all information and motivation is in the draft)