### PR TITLE
 Reflect that `Expunge` can be called on resources in the `CREATING` state

### DIFF
--- a/aip/general/0164.md
+++ b/aip/general/0164.md
@@ -101,8 +101,9 @@ rpc UndeleteBook(UndeleteBookRequest) returns (google.longrunning.Operation) {
 ### Expunge
 
 Resources that support soft delete **may** provide an `Expunge` custom method to
-allow users to trigger immediate permanent deletion on resources that are currently
-in a `CREATING`, `READY` or `SOFT_DELETED` state (e.g., `delete_time` is set).
+allow users to trigger immediate permanent deletion of a resource. This method can
+operate on resources that are currently in a `CREATING`, `READY` or `SOFT_DELETED`
+state (e.g., `delete_time` is set).
 
 ```proto
 // Permanently deletes a soft-deleted Book.

--- a/aip/general/0164.md
+++ b/aip/general/0164.md
@@ -100,10 +100,9 @@ rpc UndeleteBook(UndeleteBookRequest) returns (google.longrunning.Operation) {
 
 ### Expunge
 
-Resources that support soft delete **may** provide an `Expunge` custom method to 
-allow users to trigger immediate permanent deletion of a ready or soft-deleted
-resource. This method can operate on resources that are currently in a ready or 
-soft-deleted state (e.g., `delete_time` is set).
+Resources that support soft delete **may** provide an `Expunge` custom method to
+allow users to trigger immediate permanent deletion on resources that are currently
+in a `CREATING`, `READY` or `SOFT_DELETED` state (e.g., `delete_time` is set).
 
 ```proto
 // Permanently deletes a soft-deleted Book.


### PR DESCRIPTION
Update the doc to reflect that `Expunge` can be called on resources in the `CREATING` state, in addition to `READY` and `SOFT_DELETED` states.

The `Expunge` is a `Delete` mutate with a custom method, the `Delete` operation is  support `CREATING` state, so `Expunge` can supports it too.