### PR TITLE
fix(AIP-203): add oneof field behavior exception

### DIFF
--- a/aip/general/0203.md
+++ b/aip/general/0203.md
@@ -28,6 +28,8 @@ RecognitionAudio audio = 2 [(google.api.field_behavior) = REQUIRED];
   on a message or sub-message used in a request.
   - An exception to this is the AIP-154 `etag` field on a resource message,
     which **should not** have any `google.api.field_behavior` assigned.
+  - Furthermore, `oneof` fields **may** omit `google.api.field_behavior`, but
+    **should** document any specific behaviors in the comments in this case.
 - The annotation **must** include any [google.api.FieldBehavior][] values that
   accurately describe the behavior of the field.
   - `FIELD_BEHAVIOR_UNSPECIFIED` **must not** be used.


### PR DESCRIPTION
`oneof` member fields are exempt from various `google.api.field_behavior` requirements due, like needing to have at least one of optional/required/output_only and consistency checks (https://github.com/googleapis/api-linter/issues/708).

They are technically still allowed to use them, but if they choose not to (and linters will not nudge them towards using them), then they should document any specific behaviors in comments.

Internal issue http://b/527345401