### PR TITLE
chore: upgrade site-generator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@ WORKDIR /code/
 
 # Install Python packages for this project.
 COPY requirements.txt /code/requirements.txt
-RUN apk add git && \
-  pip install -r requirements.txt && \
-  apk del git
+RUN apk add git build-base && \
+  pip install "setuptools<66" && \
+  pip install --no-build-isolation -r requirements.txt && \
+  apk del git build-base
 
 # Set environment variables.
 ENV FLASK_ENV development

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-git+https://github.com/aip-dev/site-generator.git@v0.6.6#egg=aip-site-generator
+# Corresponds to v0.6.6.
+git+https://github.com/aip-dev/site-generator.git@c5cb78b347d82ad6244c0f4954f3f219baaa26db#egg=aip-site-generator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-aip-site-generator==0.6.0
+git+https://github.com/aip-dev/site-generator.git@v0.6.6#egg=aip-site-generator


### PR DESCRIPTION
Upgrade the version of `site-generator` used to `v0.6.6`. Using direct git commit sha dependency rather than pypi module bc there is an issue in the release pipeline. That will need to be revisited.

Also update the Dockerfile used for local serving/development.

Tested locally and site gen/serving works.